### PR TITLE
Add support for cloud-init scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ module "sysprom" {
 | labels                | Additional metadata labels for the VM and extra disk.            | map    | {}      | no       |
 | backup_enable         | Whether to enable backups for the extra disk.                    | bool   | "false" | no       |
 | external_ip           | Whether to allocate and associate a floating IP to the VM.       | bool   | "false" | no       |
+| user_data             | User data (cloud-init) script to provide when launching the VM.  | string | null    | no       |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,8 @@ resource "openstack_compute_instance_v2" "vm" {
       block_device[0].uuid,
     ]
   }
+
+  user_data = var.user_data
 }
 
 resource "openstack_compute_volume_attach_v2" "attached" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,4 +72,8 @@ variable "backup_enable" {
   type    = bool
   default = false
 }
-
+variable "user_data" {
+  description = "User data script to pass to the instance."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
### Description

Bring changes from [GitLab's PR #4](https://github.com/lidofinance/tf-openstack-gitlab-infra/pull/4) to [tf-module-openstack-vm](https://github.com/lidofinance/tf-module-openstack-vm) to allow the execution of cloud-init scripts.

Reference: https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/compute_instance_v2.html#instance-with-user-data-cloud-init

### Changes ([help](https://www.conventionalcommits.org/en/v1.0.0/#summary))

- feat: add support for cloud-init scripts via user_data param
