### PR TITLE
fix: Resolve Terraform validation errors for empty additional_disks configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,5 +91,5 @@ resource "openstack_compute_volume_attach_v2" "additional_disks_attached" {
 
   instance_id = openstack_compute_instance_v2.vm.id
   volume_id   = each.value.id
-  depends_on  = [openstack_compute_instance_v2.vm, each.value]
+  depends_on  = [openstack_compute_instance_v2.vm]
 }

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "openstack_blockstorage_volume_v3" "ext_disk" {
 
 # Multiple additional disks support
 resource "openstack_blockstorage_volume_v3" "additional_disks" {
-  for_each = { for idx, disk in var.additional_disks : idx => disk }
+  for_each = length(var.additional_disks) > 0 ? { for idx, disk in var.additional_disks : idx => disk } : {}
 
   name                 = "${var.name}-${each.value.name}"
   size                 = each.value.size
@@ -87,7 +87,7 @@ resource "openstack_compute_volume_attach_v2" "attached" {
 
 # Multiple additional disks attachment
 resource "openstack_compute_volume_attach_v2" "additional_disks_attached" {
-  for_each = openstack_blockstorage_volume_v3.additional_disks
+  for_each = length(var.additional_disks) > 0 ? openstack_blockstorage_volume_v3.additional_disks : {}
 
   instance_id = openstack_compute_instance_v2.vm.id
   volume_id   = each.value.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,16 +20,16 @@ output "team" {
 
 output "additional_disks" {
   description = "Information about the additional disks created and attached to the VM"
-  value = {
+  value = length(var.additional_disks) > 0 ? {
     volumes     = openstack_blockstorage_volume_v3.additional_disks
     attachments = openstack_compute_volume_attach_v2.additional_disks_attached
-  }
+  } : null
 }
 
 output "all_disk_volumes" {
   description = "All disk volumes (legacy extra disk + additional disks)"
   value = {
     legacy_extra_disk = var.extra_disk_size > 0 ? openstack_blockstorage_volume_v3.ext_disk[0] : null
-    additional_disks  = openstack_blockstorage_volume_v3.additional_disks
+    additional_disks  = length(var.additional_disks) > 0 ? openstack_blockstorage_volume_v3.additional_disks : {}
   }
 }


### PR DESCRIPTION
## Summary

Fixes Terraform validation errors that occurred when the `additional_disks` variable was empty (default state). The issue was caused by `for_each` expressions trying to reference `each.value` in contexts where no resources were created. Added conditional logic to handle empty disk configurations gracefully while maintaining full functionality when disks are specified.